### PR TITLE
Better style

### DIFF
--- a/cache.rb
+++ b/cache.rb
@@ -1,3 +1,5 @@
+require 'English'
+
 # A Drone CI plugin
 class DroneCache
   attr_accessor :key_path, :mount_path, :prefix, :commit_msg, :action


### PR DESCRIPTION
- Run rubocop
- Extract `#correct_rsync_args`
- Check path ending by `/`
- Use`abort` of Ruby core 